### PR TITLE
Feat/exception/3

### DIFF
--- a/Readio/src/main/java/ninegle/Readio/global/exception/BusinessException.java
+++ b/Readio/src/main/java/ninegle/Readio/global/exception/BusinessException.java
@@ -1,0 +1,15 @@
+package ninegle.Readio.global.exception;
+
+import lombok.Getter;
+import ninegle.Readio.global.exception.domain.ErrorCode;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+
+	public BusinessException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+}

--- a/Readio/src/main/java/ninegle/Readio/global/exception/domain/ErrorCode.java
+++ b/Readio/src/main/java/ninegle/Readio/global/exception/domain/ErrorCode.java
@@ -1,0 +1,93 @@
+package ninegle.Readio.global.exception.domain;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+
+	/*
+	 * Commons : 공통 예외 처리
+	 */
+	// 400
+	INVALID_REQUEST_DATA(HttpStatus.BAD_REQUEST, "요청 데이터가 올바르지 않습니다. 입력 데이터를 확인해 주세요."),
+	INVALID_PAGINATION_PARAMETER(HttpStatus.BAD_REQUEST,"요청 파라미터가 유효하지 않습니다. page는 1 이상, size는 1 이상 50 이하로 설정 해야 합니다."),
+
+	// 401
+	AUTHENTICATION_REQUIRED (HttpStatus.UNAUTHORIZED,"인증이 필요한 요청입니다. 로그인 해주세요."),
+
+	// 404
+	BOOK_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 책을 찾을 수 없습니다."),
+
+	// 500
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"예기치 못한 오류가 발생했습니다."),
+
+	/*
+	 * Books : 책 예외 처리
+	 */
+	// 400
+	INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "올바르지 않는 파일 형식 입니다."),
+
+	// 409
+	BOOK_ALREADY_EXISTS(HttpStatus.CONFLICT,"이미 등록된 책입니다."),
+	DUPLICATE_ISBN(HttpStatus.CONFLICT,"이미 등록된 ISBN입니다."),
+	DUPLICATE_ECN(HttpStatus.CONFLICT,"이미 등록된 ECN입니다."),
+	DUPLICATE_NAME(HttpStatus.CONFLICT,"이미 존재하는 이름입니다."),
+
+	/*
+	 * Library : 라이브러리 예외 처리
+	 */
+	// 400
+	NEGATIVE_PAGE_NUMBER(HttpStatus.BAD_REQUEST,"페이지 수는 음수일 수 없습니다."),
+
+	// 404
+	BOOK_READ_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 책 열람 기록을 찾을 수 없습니다."),
+	LIBRARY_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 라이브러리를 찾을 수 없습니다."),
+
+	// 409
+	LIBRAY_NAME_ALREADY_EXISTS(HttpStatus.CONFLICT,"이미 존재하는 라이브러리명입니다."),
+	BOOK_ALREADY_IN_READING_LIST(HttpStatus.CONFLICT,"이미 읽고 있는 책 목록에 존재합니다."),
+
+	/*
+	 * Preference : 관심 도서 예외 처리
+	 */
+	BOOK_ALREADY_IN_PREFERENCE(HttpStatus.CONFLICT,"이미 관심 도서로 등록된 책입니다."),
+
+	/*
+	 * Subscription : 구독 예외 처리
+	 */
+	// 400
+	INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "이메일 형식이 올바르지 않습니다."),
+	MISSING_REQUIRED_FIELD (HttpStatus.BAD_REQUEST,"필수 입력 항목을 입력해 주세요."),
+
+	// 404
+	SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 구독입니다."),
+	USER_SUBSCRIPTIONS_EMPTY(HttpStatus.NOT_FOUND,"사용자의 구독 내역이 존재하지 않습니다."),
+
+	/*
+	 * Viewer : 뷰어 예외 처리
+	 */
+	// 403
+	FORBIDDEN_BOOK_ACCESS(HttpStatus.FORBIDDEN,"이 책에 대한 열람 권한이 없습니다."),
+
+
+	/*
+	 * Publisher : 출판사 예외 처리
+	 */
+	// 404
+	PUBLISHER_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 출판사를 찾을 수 없습니다."),
+
+	// 409
+	PUBLISHER_ALREADY_EXISTS(HttpStatus.CONFLICT,"이미 존재하는 출판사입니다.")
+	;
+
+	private final HttpStatus status;
+	private final String message;
+
+	ErrorCode(HttpStatus status, String message) {
+		this.status = status;
+		this.message = message;
+	}
+
+}

--- a/Readio/src/main/java/ninegle/Readio/global/exception/dto/ErrorResponse.java
+++ b/Readio/src/main/java/ninegle/Readio/global/exception/dto/ErrorResponse.java
@@ -1,0 +1,22 @@
+package ninegle.Readio.global.exception.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+
+	private final int status;
+	private final String code;
+	private final String message;
+	private final String path;
+
+	@Builder
+	public ErrorResponse(int status, String code, String message, String path) {
+		this.status = status;
+		this.code = code;
+		this.message = message;
+		this.path = path;
+	}
+
+}

--- a/Readio/src/main/java/ninegle/Readio/global/exception/handler/GlobalExceptionHandler.java
+++ b/Readio/src/main/java/ninegle/Readio/global/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,47 @@
+package ninegle.Readio.global.exception.handler;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import ninegle.Readio.global.exception.BusinessException;
+import ninegle.Readio.global.exception.domain.ErrorCode;
+import ninegle.Readio.global.exception.dto.ErrorResponse;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	/**
+	 * 비즈니스 로직에서 발생한 예외 처리 (ErrorCode 기반)
+	 */
+	@ExceptionHandler(BusinessException.class)
+	public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+		ErrorCode code = e.getErrorCode();
+
+		StackTraceElement origin = e.getStackTrace()[0];
+		String path = origin.getClassName() + "." + origin.getMethodName()
+			+ "(" + origin.getFileName() + ":" + origin.getLineNumber() + ")";
+
+		return ResponseEntity.status(code.getStatus()).body(ErrorResponse.builder()
+			.status(code.getStatus().value())
+			.code(code.name())
+			.message(code.getMessage())
+			.path(path)
+			.build());
+	}
+
+	/**
+	 * 정의되지 않은 예외 처리 (서버 내부 오류 등)
+	 */
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ErrorResponse> handleUnknownException(Exception e) {
+		ErrorCode code = ErrorCode.INTERNAL_SERVER_ERROR;
+
+		return ResponseEntity.status(code.getStatus()).body(ErrorResponse.builder()
+			.status(code.getStatus().value())
+			.code(code.name())
+			.message(code.getMessage())
+			.build());
+	}
+
+}


### PR DESCRIPTION
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
전역(Global)에서 사용할 커스텀 예외 처리 기능 구현

#### 사용 방법
- 예외처리가 필요할 경우
```java
if (findAdmin.isEmpty()) {                                                            
       throw new BusinessException(ErrorCode.AUTHENTICATION_REQUIRED); 
}
```
- `throw new BusinessException(ErrorCode.필요한 예외처리 Enum)`을 사용하시면 됩니다.

## 스크린샷
<img width="590" alt="스크린샷 2025-05-09 오후 4 35 03" src="https://github.com/user-attachments/assets/9c0b6d31-c18f-405e-a202-d93a9aefeb1b" />

## 주의사항

- 추가 예외처리가 필요하다면 ErrorCode에 enum을 추가하면 됩니다. 
- 예시 = `INVALID_DATA(HttpStatus.BAD_REQUEST, "유효한 데이터가 아닙니다."`
 

Closes #{이슈 번호}
#3 