### PR TITLE
[feat] 구독만료 안내 이메일 구현

### DIFF
--- a/Readio/src/main/java/ninegle/Readio/ReadioApplication.java
+++ b/Readio/src/main/java/ninegle/Readio/ReadioApplication.java
@@ -3,7 +3,9 @@ package ninegle.Readio;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 @ConfigurationPropertiesScan
 public class ReadioApplication {

--- a/Readio/src/main/java/ninegle/Readio/global/config/ApplicationConfig.java
+++ b/Readio/src/main/java/ninegle/Readio/global/config/ApplicationConfig.java
@@ -1,9 +1,15 @@
 package ninegle.Readio.global.config;
 
+import org.springframework.boot.SpringApplication;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
+
+import ninegle.Readio.ReadioApplication;
 
 @Configuration
 @EnableAsync // 비동기 처리를 활성화
 public class ApplicationConfig {
+	public static void main(String[] args) {
+		SpringApplication.run(ReadioApplication.class, args);
+	}
 }

--- a/Readio/src/main/java/ninegle/Readio/mail/subscription/scheduler/SubscriptionReminderScheduler.java
+++ b/Readio/src/main/java/ninegle/Readio/mail/subscription/scheduler/SubscriptionReminderScheduler.java
@@ -1,0 +1,60 @@
+package ninegle.Readio.mail.subscription.scheduler;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import ninegle.Readio.mail.subscription.service.SubscriptionMailSender;
+import ninegle.Readio.subscription.domain.Subscription;
+import ninegle.Readio.subscription.repository.SubscriptionRepository;
+import ninegle.Readio.user.repository.UserRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SubscriptionReminderScheduler {
+
+	private final SubscriptionRepository subscriptionRepository;
+	private final UserRepository userRepository;
+	private final SubscriptionMailSender mailSender;
+
+	/**
+	 * 매일 오전 10시에 실행
+	 * 구독 종료 1일 전 또는 당일인 사용자에게 메일 발송
+	 */
+	//@Scheduled(cron = "0 * * * * *") // 테스트용: 매 분 실행
+	@Scheduled(cron = "0 0 10 * * *") // 매일 오전 10시
+	public void sendSubscriptionReminders() {
+		LocalDateTime now = LocalDateTime.now();
+		LocalDate today = now.toLocalDate();
+
+		List<Subscription> subscriptions = subscriptionRepository.findAll().stream()
+			.filter(sub ->
+				isSameDay(sub.getExpDate(), today) || isSameDay(sub.getExpDate(), today.plusDays(1))
+			)
+			.toList();
+
+		for (Subscription sub : subscriptions) {
+			userRepository.findById(sub.getUserId()).ifPresent(user -> {
+				if (isSameDay(sub.getExpDate(), today)) {
+					mailSender.sendExpirationTodayMail(user, sub); // 종료 당일
+				} else {
+					mailSender.sendExpirationSoonMail(user, sub); // 하루 전
+				}
+			});
+		}
+
+		log.info("구독 만료 알림 메일 작업 완료: 총 {}건", subscriptions.size());
+	}
+
+
+	private boolean isSameDay(LocalDateTime dateTime, LocalDate targetDate) {
+		return dateTime.toLocalDate().isEqual(targetDate);
+	}
+}

--- a/Readio/src/main/java/ninegle/Readio/mail/subscription/service/SubscriptionMailSender.java
+++ b/Readio/src/main/java/ninegle/Readio/mail/subscription/service/SubscriptionMailSender.java
@@ -34,6 +34,21 @@ public class SubscriptionMailSender {
 		send(user.getEmail(), subject, body);
 	}
 
+	@Async
+	public void sendExpirationSoonMail(User user, Subscription subscription) {
+		String subject = "[Readio] 구독이 곧 만료됩니다 (1일 전)";
+		String body = templateProvider.buildExpirationSoonMailBody(user.getNickname(), subscription);
+		send(user.getEmail(), subject, body);
+	}
+
+	@Async
+	public void sendExpirationTodayMail(User user, Subscription subscription) {
+		String subject = "[Readio] 구독이 오늘 만료됩니다";
+		String body = templateProvider.buildExpirationTodayMailBody(user.getNickname(), subscription);
+		send(user.getEmail(), subject, body);
+	}
+
+
 	//공통 메일 전송 메서드
 	private void send(String to, String subject, String body) {
 		try {

--- a/Readio/src/main/java/ninegle/Readio/mail/subscription/service/SubscriptionMailTemplateProvider.java
+++ b/Readio/src/main/java/ninegle/Readio/mail/subscription/service/SubscriptionMailTemplateProvider.java
@@ -84,4 +84,66 @@ public class SubscriptionMailTemplateProvider {
 		);
 	}
 
+	//구독 만료하루전 알림
+	public String buildExpirationSoonMailBody(String nickname, Subscription subscription) {
+		String reNickname = StringUtils.hasText(nickname) ? nickname : "회원";
+
+		return String.format("""
+		안녕하세요, %s님.
+		Readio의 여정은 즐거우셨나요?
+	
+		회원님의 구독이 내일인 %s에 만료됩니다.
+		지속적인 전자책 경험을 위해 구독 갱신을 권장드립니다.
+	
+		📌 구독 정보 안내
+		• 구독 종료일: %s
+	
+		언제나 더 나은 콘텐츠와 서비스를 제공하기 위해 노력하겠습니다.
+		Readio와 함께 더 많은 이야기를 이어가 주세요.
+	
+		감사합니다.
+		Readio 팀 드림
+	
+		© 2025. Readio, Inc. All rights reserved.
+		본 메일은 발신 전용입니다.
+	
+		------------------------------------------------------------
+		주식회사 Readio | 프로그래머스 2차 프로젝트 리디오
+		전화번호: 02-123-456 | 전자책서비스를 여러분에게 제공합니다.
+		Copyright © 2025 by Readio, Inc. All rights reserved.
+		""",
+			reNickname, subscription.getExpDate().toLocalDate(), subscription.getExpDate().toLocalDate());
+	}
+
+	//구독 만료일 알림
+	public String buildExpirationTodayMailBody(String nickname, Subscription subscription) {
+		String reNickname = StringUtils.hasText(nickname) ? nickname : "회원";
+
+		return String.format("""
+		안녕하세요, %s님.
+		Readio와 함께한 시간은 즐거우셨나요?
+	
+		회원님의 구독이 오늘인 %s에 만료됩니다.
+		이용에 불편함 없도록, 빠른 시일 내 구독 갱신을 추천드립니다.
+	
+		📌 구독 정보 안내
+		• 구독 종료일: %s
+	
+		다양한 전자책 콘텐츠와 이야기, Readio는 언제나 여러분을 기다리고 있습니다.
+	
+		감사합니다.
+		Readio 팀 드림
+	
+		© 2025. Readio, Inc. All rights reserved.
+		본 메일은 발신 전용입니다.
+	
+		------------------------------------------------------------
+		주식회사 Readio | 프로그래머스 2차 프로젝트 리디오
+		전화번호: 02-123-456 | 전자책서비스를 여러분에게 제공합니다.
+		Copyright © 2025 by Readio, Inc. All rights reserved.
+		""",
+			reNickname, subscription.getExpDate().toLocalDate(), subscription.getExpDate().toLocalDate());
+	}
+
+
 }


### PR DESCRIPTION
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
-구독 만료 1일전에 : 구독 만료 1일전을 알려주는 알림메일이 발송
-구독 만료 당일 : 구독만료일 알림메일 발송

## 스크린샷

### 구독 만료 알림 예)

<img width="250" alt="스크린샷 2025-05-15 오후 3 29 21" src="https://github.com/user-attachments/assets/e4d4c3e5-ab2c-42b7-9744-ec57325d2daa" />

<br>

### 구독 만료 1일전
<img width="406" alt="스크린샷 2025-05-15 오후 3 29 03" src="https://github.com/user-attachments/assets/0f063fbc-789f-4c23-8839-aa7b15220a40" />

<br>

### 구독 만료일
<img width="450" alt="스크린샷 2025-05-15 오후 3 29 11" src="https://github.com/user-attachments/assets/815e29b0-8853-45e7-96a3-79e8cc0456a9" />


## 주의사항

Closes #{이슈 번호}
