### PR TITLE
fix: 프론트 api 요청 구조 변경

### DIFF
--- a/Readio/src/main/java/ninegle/Readio/user/config/SecurityConfig.java
+++ b/Readio/src/main/java/ninegle/Readio/user/config/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig {
 					.requestMatchers("/admin/**").hasRole("ADMIN")
 					.requestMatchers(HttpMethod.GET, "/books/**").permitAll()
 					.requestMatchers(HttpMethod.GET, "/category").permitAll()
-					.requestMatchers("/viewer/**").hasAnyRole("USER", "ADMIN")
+					.requestMatchers("/viewer/**").permitAll()
 					.anyRequest().hasAnyRole("USER", "ADMIN"); //나머지 요청은 USER나 ADMiN 권한을 가져야 접근 가능
 			})
 

--- a/frontend/src/pages/book/EpubReaderPage.tsx
+++ b/frontend/src/pages/book/EpubReaderPage.tsx
@@ -264,7 +264,7 @@ const EpubReaderPage: React.FC = () => {
 
           const apiResponse: BookApiResponse = await response.json();
 
-          if (apiResponse.code !== 200 || !apiResponse.data?.epubUri) {
+          if (apiResponse.status !== 200 || !apiResponse.data?.epubUri) {
             throw new Error(`API 응답 오류: ${apiResponse.message}`);
           }
 


### PR DESCRIPTION
- [x] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
- 파일 깨짐 현상은 icloud의 도서에 있는 파일을 올리다보니 생긴 문제였다..
- 다운로드 받은 파일을 올리면 정상적으로 실행됨
- 문제는 파일 공개를 해줘야 이미지 책읽기가 가능
- 작업은 프론트 책읽기 api 요청 구조 중 status가 code로 되어있어서 status로 변경
## 스크린샷

## 주의사항

Closes #{이슈 번호}
#99 